### PR TITLE
slurm_cpus: count only running jobs

### DIFF
--- a/slurm_cpus
+++ b/slurm_cpus
@@ -57,4 +57,4 @@ case $1 in
         ;;
     esac
 
-squeue -o "%C" | awk 'BEGIN {s=0} {s+=$1} END {printf "slurm_cpus.value  %g\n", s}'
+squeue -o "%C" -t RUNNING| awk 'BEGIN {s=0} {s+=$1} END {printf "slurm_cpus.value  %g\n", s}'


### PR DESCRIPTION
Hi,

I was wondering why sometimes the number of Cores used was NaN.
I discover that it is related to the fact that the number of cores calculated can exceed the maximum value set, because it also counting cores for pending Job.

A quick fix was to count only cores from job in RUNNING state.
A more elegant way will be to create to metrics but I am not sure it is really useful to display number of core for pending jobs.

Regards,
Laurent

PS : I am using slurm 15.08.11
